### PR TITLE
pass messageTtl to amqplib

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -13,6 +13,7 @@ function Queue(channel, name, options) {
   this.durable = options.durable;
   this.noAck = options.noAck;
   this.tag = null;
+  this.messageTtl = options.messageTtl;
 
   this.channel
     .assertQueue(name, {
@@ -74,7 +75,7 @@ Queue.prototype.publish = function(obj, replyHandler) {
   this.channel.sendToQueue(this.name, new Buffer(msg), {
     persistent: !replyHandler,
     correlationId: id,
-    expiration: '1000',
+    expiration: this.messageTtl,
     replyTo: replyHandler ? this.channel.replyName : undefined
   });
 };


### PR DESCRIPTION
I think this is the intention here.  Use the messageTTL pass on the options and send as the expiration on the message publish.