### PR TITLE
release the replyHandler in channel.replyHandlers[]

### DIFF
--- a/lib/jackrabbit.js
+++ b/lib/jackrabbit.js
@@ -56,6 +56,9 @@ JackRabbit.prototype.onReply = function(msg) {
   var body = msg.content.toString();
   var obj = JSON.parse(body);
   replyHandler(null, obj);
+  
+  //release the replyHandler in this.channel.replyHandlers
+  delete this.channel.replyHandlers[id]; 
 };
 
 JackRabbit.prototype.close = function() {


### PR DESCRIPTION
It was causing this associative array to grow indefinitely when you keep the queue open and then publish to it. I'm using jackrabbit with a REST api built with restify and noticed the excessive use of memory after some performance testing using jmeter to send some thousands of requests. 