### PR TITLE
Simple Nack Implementation

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -53,7 +53,12 @@ Queue.prototype.onMessage = function(msg) {
   var hasReply = msg.properties.replyTo;
 
   if (hasReply && !this.noAck) this.channel.ack(msg);
-  this.handler(obj, function(reply) {
+  this.handler(obj, function(reply, opts) {
+    if (!opts) opts = {};    
+    if (reply === false) {
+      var requeue = (typeof opts.requeue !== 'undefined' ? opts.requeue : true);
+      return this.channel.nack(msg, false, requeue);
+    }
     if (hasReply) {
       var replyBuffer = new Buffer(JSON.stringify(reply || ''));
       this.channel.sendToQueue(msg.properties.replyTo, replyBuffer, {


### PR DESCRIPTION
To nack a message, use `false` as the first argument to the ack function passed to the handler. 

```js
queue.handle('my-queue', function(msg, ack){
  process_msg( msg, function(error){

    // nack
    if(error) ack(false);

    else ack('message processing successful');
  });  
});
```
It does a strict comparison `===` so you can pass falsy ack messages as long as it isn't actually `false` being passed.

By default it will requeue the message, but if you don't want that ... 

```js
queue.handle('my-queue', function(msg, ack){
  process_msg( msg, function(error){

    // nack no requeue
    if(error) ack(false, {requeue: false});
    
    else ack('message processing successful');
  });  
});
```