### PR TITLE
Feature/pausable queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 npm-debug.log
+
+.idea
+*.iml

--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -1,4 +1,3 @@
-var amqp = require('amqplib/callback_api');
 var _ = require('lodash');
 var EventEmitter = require('events').EventEmitter;
 var uuid = require('node-uuid');
@@ -149,7 +148,7 @@ function exchange(name, type, options) {
     channel = chan;
     channel.on('close', bail.bind(this, new Error('channel closed')));
     channel.on('drain', onDrain);
-    emitter.emit('connected');
+    emitter.emit('connected', channel);
     if (isDefault(emitter.name, emitter.type) || isNameless(emitter.name)) {
       onExchange(undefined, { exchange: emitter.name });
     }
@@ -163,7 +162,7 @@ function exchange(name, type, options) {
     replyQueue.connect(connection);
     replyQueue.once('ready', function() {
       ready = true;
-      emitter.emit('ready');
+      emitter.emit('ready', replyQueue);
     });
   }
 

--- a/lib/jackrabbit.js
+++ b/lib/jackrabbit.js
@@ -39,7 +39,7 @@ function jackrabbit(url) {
       // (eg, how do they determine if closing is an illegal operation?)
       connection.close(function(err) {
         if (callback) callback(err);
-        rabbit.emit('close');
+        rabbit.emit('close', connection);
       });
     }
     catch (e) {
@@ -79,6 +79,6 @@ function jackrabbit(url) {
     if (err) return bail(err);
     connection = conn;
     connection.on('close', bail.bind(this));
-    rabbit.emit('connected');
+    rabbit.emit('connected', connection);
   }
 }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -89,7 +89,7 @@ function queue(options) {
   function onConsume(err, info) {
     if (err) return bail(err);
     consumerTag = info.consumerTag; // required to stop consuming
-    emitter.emit('consuming');
+    emitter.emit('consuming', consumerTag);
   }
 
   function bail(err) {
@@ -105,7 +105,7 @@ function queue(options) {
     channel = chan;
     channel.prefetch(emitter.options.prefetch);
     channel.on('close', bail.bind(this, new Error('channel closed')));
-    emitter.emit('connected');
+    emitter.emit('connected', channel);
     channel.assertQueue(emitter.name, emitter.options, onQueue);
   }
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,6 +1,7 @@
 var amqp = require('amqplib/callback_api');
 var _ = require('lodash');
 var EventEmitter = require('events').EventEmitter;
+var Promise = require('bluebird');
 
 var DEFAULT_QUEUE_OPTIONS = {
   exclusive: false,
@@ -21,7 +22,7 @@ module.exports = queue;
 
 function queue(options) {
   options = options || {};
-  var channel, consumerTag;
+  var channel, consumerTag, queueReady = Promise.defer();
   var emitter = _.extend(new EventEmitter(), {
     name: options.name,
     options: _.extend({}, DEFAULT_QUEUE_OPTIONS, options),
@@ -36,10 +37,23 @@ function queue(options) {
   }
 
   function consume(callback, options) {
-    emitter.once('ready', function() {
-      var opts = _.extend({}, DEFAULT_CONSUME_OPTIONS, options);
-      channel.consume(emitter.name, onMessage, opts, onConsume);
+    queueReady.promise.then(function () {
+        var opts = _.extend({}, DEFAULT_CONSUME_OPTIONS, options);
+        channel.consume(emitter.name, onMessage, opts, onConsume);
     });
+
+    return {
+      name: emitter.name,
+      pause: function () {
+        if (consumerTag) {
+          channel.cancel(consumerTag);
+        }
+        consumerTag = null;
+      },
+      resume: function () {
+        return emitter.consume(callback, options);
+      }
+    };
 
     function onMessage(msg) {
       var data = parseMessage(msg);
@@ -110,8 +124,12 @@ function queue(options) {
   }
 
   function onQueue(err, info) {
-    if (err) return bail(err);
+    if (err) {
+        queueReady.reject(err);
+        return bail(err);
+    }
     emitter.name = info.queue;
     emitter.emit('ready');
+    queueReady.resolve();
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "amqplib": "0.4.0",
+    "bluebird": "2.10.2",
     "lodash": "^3.10.1",
     "node-uuid": "1.4.7"
   },

--- a/test/exchange.test.js
+++ b/test/exchange.test.js
@@ -1,3 +1,4 @@
+var Promise = require('bluebird');
 var assert = require('chai').assert;
 var amqp = require('amqplib/callback_api');
 var exchange = require('../lib/exchange');
@@ -58,12 +59,16 @@ describe('exchange', function() {
     it('emits a "connected" event', function(done) {
       exchange('', 'direct')
         .connect(this.connection)
-        .once('connected', done);
+          .once('connected', function (channel) {
+            assert.ok(channel.consume);
+            done();
+          });
     });
   });
 
   describe('#queue', function() {
     describe('with no options', function() {
+      var directExchange;
       before(function(done) {
         amqp.connect(process.env.RABBIT_URL, function(err, conn) {
           assert.ok(!err);
@@ -72,12 +77,34 @@ describe('exchange', function() {
         }.bind(this));
       });
       before(function() {
-        this.q = exchange('', 'direct')
+        directExchange = exchange('', 'direct');
+        this.q = directExchange
           .connect(this.connection)
-          .queue();
+            .queue({name: 'someQueue'});
       });
       it('returns a queue instance', function() {
         assert.ok(this.q.consume);
+      });
+      describe('delayed consume', function () {
+        it('should be able to attach consumer', function () {
+          var consumerSpyInvoked = false;
+
+          function consumerSpy() {
+            consumerSpyInvoked = true;
+          }
+
+          var q = this.q;
+          return new Promise(function (resolve) {
+            q.once('ready', resolve);
+          }).then(function () {
+                q.consume(consumerSpy, {noAck: true});
+                directExchange.publish('abc', {key: 'someQueue'});
+              })
+              .delay(100)
+              .then(function () {
+                assert.equal(true, consumerSpyInvoked);
+              });
+        });
       });
     });
   });

--- a/test/jackrabbit.test.js
+++ b/test/jackrabbit.test.js
@@ -7,7 +7,10 @@ describe('jackrabbit', function(){
     describe('with a valid server url', function() {
       it('emits a "connected" event', function(done) {
         this.r = jackrabbit(process.env.RABBIT_URL);
-        this.r.once('connected', done);
+        this.r.once('connected', function (connection) {
+          assert.ok(connection.createChannel);
+          done();
+        });
       });
       it('references a Connection object', function() {
         var c = this.r.getInternals().connection;
@@ -59,18 +62,27 @@ describe('jackrabbit', function(){
       it('passes the connection to the exchange', function(done) {
         jackrabbit(process.env.RABBIT_URL)
           .default()
-          .once('connected', done);
+          .once('connected', function(channel) {
+            assert.ok(channel.consume);
+            done();
+          });
       })
     });
     describe('after connection is established', function() {
       before(function(done) {
         this.r = jackrabbit(process.env.RABBIT_URL);
-        this.r.once('connected', done);
+        this.r.once('connected', function (connection) {
+          assert.ok(connection.createChannel);
+          done();
+        });
       });
       it('passes the connection to the exchange', function(done) {
         this.r
           .default()
-          .once('connected', done);
+          .once('connected', function (channel) {
+            assert.ok(channel.consume);
+            done();
+          });
       });
     });
   });
@@ -104,18 +116,27 @@ describe('jackrabbit', function(){
       it('passes the connection to the exchange', function(done) {
         jackrabbit(process.env.RABBIT_URL)
           .direct()
-          .once('connected', done);
+          .once('connected', function (channel) {
+            assert.ok(channel.consume);
+            done();
+          });
       })
     });
     describe('after connection is established', function() {
       before(function(done) {
         this.r = jackrabbit(process.env.RABBIT_URL);
-        this.r.once('connected', done);
+        this.r.once('connected', function (connection) {
+          assert.ok(connection.createChannel);
+          done();
+        });
       });
       it('passes the connection to the exchange', function(done) {
         this.r
           .direct()
-          .once('connected', done);
+          .once('connected', function (channel) {
+            assert.ok(channel.consume);
+            done();
+          });
       });
     });
   });
@@ -149,18 +170,27 @@ describe('jackrabbit', function(){
       it('passes the connection to the exchange', function(done) {
         jackrabbit(process.env.RABBIT_URL)
           .fanout()
-          .once('connected', done);
+          .once('connected', function (channel) {
+            assert.ok(channel.consume);
+            done();
+          });
       })
     });
     describe('after connection is established', function() {
       before(function(done) {
         this.r = jackrabbit(process.env.RABBIT_URL);
-        this.r.once('connected', done);
+        this.r.once('connected', function (connection) {
+          assert.ok(connection.createChannel);
+          done();
+        });
       });
       it('passes the connection to the exchange', function(done) {
         this.r
           .fanout()
-          .once('connected', done);
+          .once('connected', function (channel) {
+            assert.ok(channel.consume);
+            done();
+          });
       });
     });
   });
@@ -168,11 +198,17 @@ describe('jackrabbit', function(){
   describe('#close', function() {
     before(function(done) {
       this.r = jackrabbit(process.env.RABBIT_URL);
-      this.r.once('connected', done);
+      this.r.once('connected', function (connection) {
+        assert.ok(connection.createChannel);
+        done();
+      });
     });
     it('emits a "close" event', function(done) {
       this.r.close();
-      this.r.once('close', done);
+      this.r.once('close', function (connection) {
+        assert.ok(connection.createChannel);
+        done();
+      });
     });
     it('clears the connection', function() {
       assert.ok(!this.r.getInternals().connection);


### PR DESCRIPTION
[BunnyPaws](https://github.com/agco/bunny-paws) want's to add ability to pause and resume consumers for all or specific queue.That require's Jackrabbit to register consumer not only on queue ready event but always when the consume method is invoked (and queue is ready), so also long after the event is fired.
