### PR TITLE
add "bound" event when routingKeys have been bound to the queue.

### DIFF
--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -73,8 +73,14 @@ function exchange(name, type, options) {
       // the default exchange has implicit bindings to all queues
       if (!isNameless(emitter.name)) {
         var keys = options.keys || [options.key];
-        keys.forEach(bindKey);
 
+        bindKeys(keys)
+        .then(function emitBoundEvent(res) {
+          newQueue.emit('bound')
+        })
+        .catch(function bailOut(err) {
+          bail(err);
+        });
       }
     });
 
@@ -88,13 +94,27 @@ function exchange(name, type, options) {
     }
     return newQueue;
 
-    function bindKey(key) {
-      channel.bindQueue(newQueue.name, emitter.name, key, {}, onBind);
+    // return a promise when all keys are bound
+    function bindKeys(keys) {
+      var promises = [];
+
+      // returns a promise when a key is bound
+      function bindKey(key) {
+        var deferred = Promise.defer();
+
+        channel.bindQueue(newQueue.name, emitter.name, key, {}, function onBind(err, ok) {
+          if (err) return deferred.reject(err);
+          return deferred.resolve(ok);
+        });
+        return deferred.promise;
+      }
+
+      keys.forEach(function (key) {
+        promises.push(bindKey(key));
+      });
+      return Promise.all(promises); // bind keys in parallel
     }
 
-    function onBind(err, ok) {
-      if (err) return bail(err);
-    }
   }
 
   function publish(message, options) {

--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -74,6 +74,7 @@ function exchange(name, type, options) {
       if (!isNameless(emitter.name)) {
         var keys = options.keys || [options.key];
         keys.forEach(bindKey);
+
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   },
   "devDependencies": {
     "chai": "^3.2.0",
-    "mocha": "^2.2.5",
+    "mocha": "^2.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,5 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "mocha": "^2.2.5",
-    "node-uuid": "1.4.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "chai": "^3.2.0",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "node-uuid": "1.4.7"
   }
 }

--- a/test/bindKey.spec.js
+++ b/test/bindKey.spec.js
@@ -1,0 +1,45 @@
+/**
+ * This test exposes a bug in that a queue with many routingKeys can be created,
+ * and used before all routingKeys have been created.
+ *
+ */
+
+// dependencies
+var assert = require('chai').assert;
+var jackrabbit = require('../lib/jackrabbit');
+var uuid = require('node-uuid');
+
+
+// variables
+var queueName = 'test-queue-many-routing-keys';
+
+describe.only('Queue creation', function () {
+	before(function establishConnectionToRabbitMQ(done) {
+		var that  = this;
+		this.r = jackrabbit(process.env.RABBIT_URL);
+		this.e = this.r.topic('test-bindKey');
+		this.r.once('connected', function () {
+			done();
+		});
+	});
+
+	it('should have all routingKeys functional', function (done) {
+		var uniqueMessage = uuid.v4();  // messages are unique between tests
+		var exchange = this.e;
+		var options = {
+			keys: ['a', 'b', 'c', 'd', 'e']
+		}
+		var lastRoutingKey = options.keys[options.keys.length - 1];
+		var q = this.e.queue(options);
+
+		q.consume(function (data, ack, nack, msg) {
+			assert.equal(uniqueMessage, data);
+			assert.equal(msg.fields.routingKey, lastRoutingKey);
+			done();
+			ack();
+		}, {});
+		q.once('ready', function () {
+			exchange.publish(uniqueMessage, { key: lastRoutingKey });
+		});
+	});
+});

--- a/test/bindKey.spec.js
+++ b/test/bindKey.spec.js
@@ -13,7 +13,7 @@ var uuid = require('node-uuid');
 // variables
 var queueName = 'test-queue-many-routing-keys';
 
-describe.only('Queue creation', function () {
+describe('Queue creation', function () {
 	before(function establishConnectionToRabbitMQ(done) {
 		var that  = this;
 		this.r = jackrabbit(process.env.RABBIT_URL);
@@ -23,7 +23,7 @@ describe.only('Queue creation', function () {
 		});
 	});
 
-	it('should have all routingKeys functional', function (done) {
+	it('emits a "bound" event when all routing keys have been bound to the queue', function (done) {
 		var uniqueMessage = uuid.v4();  // messages are unique between tests
 		var exchange = this.e;
 		var options = {
@@ -38,7 +38,7 @@ describe.only('Queue creation', function () {
 			done();
 			ack();
 		}, {});
-		q.once('ready', function () {
+		q.once('bound', function () {
 			exchange.publish(uniqueMessage, { key: lastRoutingKey });
 		});
 	});


### PR DESCRIPTION
When creating a queue, `routingKeys` are bound to that queue. This is an asynchronous call. So it's possible that the queue can be created and we can start sending messages to it. However those first few messages may be dropped, since the `routingKey` has not been bound to the queue yet.

This feature PR raises a "`bound`" event when all keys have been bound to a queue. *(with tests)*.