### PR TITLE
Allow passing in options for the amqplib connect command

### DIFF
--- a/lib/jackrabbit.js
+++ b/lib/jackrabbit.js
@@ -5,8 +5,11 @@ var exchange = require('./exchange');
 
 module.exports = jackrabbit;
 
-function jackrabbit(url) {
+function jackrabbit(url, opts) {
   if (!url) throw new Error('url required for jackrabbit connection');
+
+  // default to empty options object
+  opts = opts || {}
 
   // state
   var connection;
@@ -20,7 +23,7 @@ function jackrabbit(url) {
     getInternals: getInternals
   });
 
-  amqp.connect(url, onConnection);
+  amqp.connect(url, opts, onConnection);
   return rabbit;
 
   // public


### PR DESCRIPTION
This fix allows passing in additional options to the amqplib connect command. I needed this to connect to a server with SSL enabled. 

For future reference, this is the code I used to create the object to pass to amqplib.

``` javascript
require('ssl-root-cas').inject()
const https = require('https')

module.exports = function rabbitConfig(settings) {

  // Define a the SSL config for jackrabbit
  const cas = https.globalAgent.options.ca || []

  // Optionally add SSL cert to the registry
  if (settings.sslKey) {
    // .replace() because this key lives as a string in an ENV var
    cas.push(settings.sslKey.replace(/\\n/g, '\n'))
  }

  return {
    ca: cas // This object is passed into amqplib's options
  }
}
```
