### PR TITLE
Add noReply option to exchange and enable passing of options paramaters during initialization

### DIFF
--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -15,7 +15,8 @@ var DEFAULT_EXCHANGE_OPTIONS = {
   durable: true,
   internal: false,
   autoDelete: false,
-  alternateExchange: undefined
+  alternateExchange: undefined,
+  noReply: false
 };
 
 var DEFAULT_PUBLISH_OPTIONS = {
@@ -44,13 +45,14 @@ function exchange(name, type, options) {
   var ready = false;
   var connection, channel;
   var publishing = 0;
-  var replyQueue = queue({ exclusive: true });
+  var options = _.extend({}, DEFAULT_EXCHANGE_OPTIONS, options)
+  var replyQueue = !options.noReply && queue({ exclusive: true });
   var pendingReplies = {};
 
   var emitter = _.extend(new EventEmitter(), {
     name: name,
     type: type,
-    options: _.extend({}, DEFAULT_EXCHANGE_OPTIONS, options),
+    options: options,
     queue: createQueue,
     connect: connect,
     publish: publish
@@ -61,8 +63,8 @@ function exchange(name, type, options) {
   function connect(con) {
     connection = con;
     connection.createChannel(onChannel);
-    replyQueue.on('close', bail.bind(this));
-    replyQueue.consume(onReply, { noAck: true });
+    replyQueue && replyQueue.on('close', bail.bind(this));
+    replyQueue && replyQueue.consume(onReply, { noAck: true });
     return emitter;
   }
 
@@ -172,11 +174,14 @@ function exchange(name, type, options) {
 
   function onExchange(err, info) {
     if (err) return bail(err);
-    replyQueue.connect(connection);
-    replyQueue.once('ready', function() {
+    replyQueue && replyQueue.connect(connection);
+
+    function onReady() {
       ready = true;
       emitter.emit('ready');
-    });
+    }
+
+    replyQueue ? replyQueue.once('ready', onReady) : onReady();
   }
 
   function isDefault(name, type) {

--- a/lib/jackrabbit.js
+++ b/lib/jackrabbit.js
@@ -47,13 +47,13 @@ function jackrabbit(url) {
     }
   }
 
-  function createDefaultExchange() {
-    return createExchange('direct')('');
+  function createDefaultExchange(options) {
+    return createExchange('direct')('', options);
   }
 
   function createExchange(type) {
-    return function(name) {
-      var newExchange = exchange(name, type);
+    return function(name, options) {
+      var newExchange = exchange(name, type, options);
       if (connection) {
         newExchange.connect(connection);
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Hunter Loftis <hunter@hunterloftis.com>",
   "license": "MIT",
   "dependencies": {
-    "amqplib": "0.4.0",
+    "amqplib": "0.4.2",
     "lodash": "^3.10.1",
     "node-uuid": "1.4.7"
   },


### PR DESCRIPTION
If noReply options is set for an exchange, an exclusive reply queue will not be automatically created for that exchange.

Example usage:
```javascript
var defaultExchange = jackrabbit.default({ noReply: true });
var fanoutExchange = jackrabbit.fanout('failed', { noReply: true });
```

Handles #53 