### PR TITLE
add options

### DIFF
--- a/lib/jackrabbit.js
+++ b/lib/jackrabbit.js
@@ -5,7 +5,7 @@ var exchange = require('./exchange');
 
 module.exports = jackrabbit;
 
-function jackrabbit(url) {
+function jackrabbit(url, options) {
   if (!url) throw new Error('url required for jackrabbit connection');
 
   // state
@@ -20,7 +20,7 @@ function jackrabbit(url) {
     getInternals: getInternals
   });
 
-  amqp.connect(url, onConnection);
+  amqp.connect(url, options || {}, onConnection);
   return rabbit;
 
   // public


### PR DESCRIPTION
Need to specify the options when connection to amqps.  Compose rabbitmq use the TLS server name extension which isn't supported out of the box by amqplib so the servername option needs to be specified.

