### PR TITLE
Fix memory leak: delete pending reply callback after reply

### DIFF
--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -150,7 +150,10 @@ function exchange(name, type, options) {
 
   function onReply(data, ack, nack, msg) {
     var replyCallback = pendingReplies[msg.properties.correlationId];
-    if (replyCallback) replyCallback(data);
+    if (replyCallback) {
+      replyCallback(data);
+      delete pendingReplies[msg.properties.correlationId];
+    }
   }
 
   function bail(err) {


### PR DESCRIPTION
The exchange has a memory leak that's only noticeable in high volume traffic. We append a callback function to `pendingReplies` but never remove it once it's called.

Here are some screenshots of our worker memory before and after this fix:
<img width="328" alt="Screenshot_2018-03-15_13_22_39_png" src="https://user-images.githubusercontent.com/4271679/59902979-908bfb00-93b4-11e9-89bb-02a72fe603b3.png">

After:
![Screen Shot 2018-04-11 at 3 50 54 PM](https://user-images.githubusercontent.com/4271679/59903001-a1d50780-93b4-11e9-8c6a-59acebde270a.png)
