### PR TITLE
update buffer use and change ondrain to settimeout

### DIFF
--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -136,7 +136,7 @@ function exchange(name, type, options) {
       var drained = channel.publish(
         emitter.name,
         opts.key,
-        new Buffer(msg),
+        Buffer.from(msg),
         opts
       );
       if (drained) onDrain();
@@ -161,12 +161,12 @@ function exchange(name, type, options) {
   }
 
   function onDrain() {
-    setImmediate(function() {
+    setTimeout(function() {
       publishing--;
       if (publishing === 0) {
         emitter.emit("drain");
       }
-    });
+    }, 0);
   }
 
   function onChannel(err, chan) {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -89,9 +89,9 @@ function queue(options) {
 
   function encodeMessage(message, contentType) {
     if (contentType === "application/json") {
-      return new Buffer(JSON.stringify(message));
+      return Buffer.from(JSON.stringify(message));
     }
-    return new Buffer(message.toString());
+    return Buffer.from(message.toString());
   }
 
   function parseMessage(msg) {


### PR DESCRIPTION
i fix it with change new Buffer to Buffer.from, because this error
deprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
 i also change ondrain, because i found that previous version that can't publish data

my node version is v14.16.0